### PR TITLE
Use valid category in library.properties

### DIFF
--- a/CalvinMini/library.properties
+++ b/CalvinMini/library.properties
@@ -4,6 +4,6 @@ author=
 maintainer= 
 sentence=Enables an implementation Calvin minimal runtime on an Arduino DUE board. 
 paragraph=Use this to enable a Calvin minimal runtime on an Arduino board<br>This allows the user to join a mesh network in order to setup distributed actors for e.g sensor readings.<br>
-category=sam
+category=Communication
 url=https://github.com/MalmoUniversity-DA366A/calvin-arduino
 architectures=sam 


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'sam' in library Calvin Arduino is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format